### PR TITLE
Optimize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,39 @@
-language: cpp
+language: generic
 
 sudo: false
 
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.5
+     - ubuntu-toolchain-r-test
     packages:
-      - clang-3.5
+     - libstdc++-4.9-dev
 
 matrix:
   include:
      # Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.12.2" # node abi 14
+       env: NODE_VERSION="0.10" # node abi 11
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="4" # node abi 46
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="6" # node abi 48
      # OS X
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.12.2" # node abi 14
+       env: NODE_VERSION="0.10" # node abi 11
+       osx_image: xcode8.2
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="4" # node abi 46
+       osx_image: xcode8.2
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="6" # node abi 48
+       osx_image: xcode8.2
 
 env:
   global:
@@ -33,20 +41,18 @@ env:
     - secure: "mCGuAoX0V75Kl7EBDw5JRZc1KrBglrNdMgFKE7auIl1BFgolHJ0wFodw0F4AZ2uy3SQi3Dfz+yVotpz6NgbLSlqSS1yO66tu0zk0gI3BkaDJ/8A2rfZUNKVEo1nzhM271/9PD0zqS1rUZn5hQPHRwRy7fBNfcXE/CPAvwL8AyBncGB5Iswn2GNett6ffGR+Y7NWBNLePXxiDTBIxVBqBFvvuUschMyuZLdSzKXGMKtKdqVaOihZ3j8tHE7szmnl/wYAO7bT1jhnGnS/K3CcHrZUx+xkppow7UpFD8EcCDgZgs73T1UmVywMaVBvTNznCBlj+qGpsOVbyfo6Xe2DjstBFvJWloTYMoSKwtYNth5rftVnrhKNXdVq+oDuHHtRo/7DnFAfjZErU0QyXBUCBS5MdIoHJrND6U0qODJABBFk86f/4mMEULYzJIYxsp7wP2RpApkGJarvIsaOnAz333ddTeDgamTV6sPka2HbMFgaHQ6lLvc3I4fNdTTMW34xoKVH1D3VKQtAHCeW+L/MUQI6+jFA4Y8XMoh/+IEBXrhh9UayBqjKBYVli/mxmJ7mlq3eMRQMV5hH+kq5KWL3+EzWOXtlyVO7Se5BEqoPuBO5nKKdEtIht3jW9Iy3xnGCVcEEGgg3pOQ41+2yX0vVth8lZ+M/gn04oxTi+1n0heLc="
 
 before_install:
-  - if [[ $(uname -s) == 'Linux' ]]; then
-      export CXX="clang++-3.5";
-      export CC="clang-3.5";
-    fi;
-  - rm -rf ~/.nvm/ && git clone --depth 1 https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  - nvm install $NODE_VERSION
-  - nvm use $NODE_VERSION
+ # install clang++ via mason
+ - mkdir /tmp/mason && curl -sSfL https://github.com/mapbox/mason/archive/v0.5.0.tar.gz | tar --gunzip --extract --strip-components=1 --directory=/tmp/mason
+ - /tmp/mason/mason install clang++ 3.9.1
+ - export PATH=$(/tmp/mason/mason prefix clang++ 3.9.1)/bin:${PATH}
+ - export CXX=clang++-3.9
+ - source ~/.nvm/nvm.sh
+ - nvm install $NODE_VERSION
+ - nvm use $NODE_VERSION
 
 install:
-  - npm install --build-from-source --clang=1
+ - npm install --build-from-source --clang=1;
 
 script:
-  - npm test
-
-after_success:
-  - ./test/travis-publish.sh
+ - npm test
+ - ./test/travis-publish.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # unidecode-cxx
 
+[![Build Status](https://travis-ci.org/mapbox/node-unidecode-cxx.svg?branch=master)](https://travis-ci.org/mapbox/node-unidecode-cxx)
+
 This is a weekend experiment at porting [node-unidecode](https://github.com/FGRibreau/node-unidecode) to C++. All of node-unidecode's data files are compiled statically into the binary, and more is done with lookup tables rather than branches.
 
 So far it passes all of unidecode's tests except one (it doesn't handle null characters in the same way), and is about twice as fast. It definitely hasn't been battle-tested, though, and in particular, I have no idea how it will handle invalid unicode.

--- a/bench.js
+++ b/bench.js
@@ -2,28 +2,38 @@ var http = require('http');
 var unidecode = require('unidecode');
 var unidecodeCxx = require('./unidecode');
 
+var iterations = 100;
+
 function compare(data) {
     lines = data.split("\n");
 
     console.time("unidecode");
-    for (var i = 0; i < 100; i++) {
+    for (var i = 0; i < iterations; i++) {
         for (var j = 0; j < lines.length; j++) {
             unidecode(lines[j]);
         }
     }
     console.timeEnd("unidecode");
 
-    console.time("unidecodeCxx");
-    for (var i = 0; i < 100; i++) {
+    console.time("cxx decodable");
+    for (var i = 0; i < iterations; i++) {
         for (var j = 0; j < lines.length; j++) {
-            unidecodeCxx(lines[j]);
+            unidecodeCxx.decodable(lines[j]);
         }
     }
-    console.timeEnd("unidecodeCxx");
+    console.timeEnd("cxx decodable");
+
+    console.time("cxx decode");
+    for (var i = 0; i < iterations; i++) {
+        for (var j = 0; j < lines.length; j++) {
+            unidecodeCxx.decode(lines[j]);
+        }
+    }
+    console.timeEnd("cxx decode");
 }
 
 console.log("Retrieving file...");
-http.get("http://www.gutenberg.org/files/34013/34013-0.txt", function(response) {
+http.get("http://mapbox.s3.amazonaws.com/apendleton/34013-0.txt", function(response) {
     var body = '';
     response.on('data', function (chunk) {
         body += chunk;

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,33 +1,38 @@
 {
-  "targets": [
+  'includes': [ 'common.gypi' ],
+  'targets': [
     {
-      "target_name": "unidecode",
-      "sources": [
-        "src/addon.cxx"
+      'target_name': '<(module_name)',
+      'product_dir': '<(module_path)',
+      'sources': [
+        "./src/addon.cxx"
       ],
-      "include_dirs"  : [
-            "<!(node -e \"require('nan')\")"
+      "include_dirs" : [
+          'src/',
+          '<!(node -e \'require("nan")\')'
       ],
-      "cflags": ["-g"],
-      'cflags_cc!': [ '-fno-exceptions' ],
-      'conditions': [
-        ['OS=="mac"', {
-          'xcode_settings': {
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-          }
-        }]
-      ]
-    },
-    {
-      "target_name": "action_after_build",
-      "type": "none",
-      "dependencies": [ "<(module_name)" ],
-      "copies": [
-        {
-          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
-          "destination": "<(module_path)"
-        }
-      ]
+      'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
+      'cflags_cc' : [
+          '-Wconversion'
+      ],
+      'ldflags': [
+        '-Wl,-z,now',
+      ],
+      'xcode_settings': {
+        'OTHER_LDFLAGS':[
+          '-Wl,-bind_at_load'
+        ],
+        'OTHER_CPLUSPLUSFLAGS':[
+           '-Wshadow',
+           '-Wconversion'
+        ],
+        'GCC_ENABLE_CPP_RTTI': 'YES',
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'MACOSX_DEPLOYMENT_TARGET':'10.8',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'CLANG_CXX_LANGUAGE_STANDARD':'c++14',
+        'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
+      }
     }
   ]
 }

--- a/common.gypi
+++ b/common.gypi
@@ -1,0 +1,45 @@
+{
+  'target_defaults': {
+    'default_configuration': 'Release',
+    'cflags_cc' : [
+      '-std=c++14',
+    ],
+    'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
+    'configurations': {
+      'Debug': {
+        'defines!': [
+          'NDEBUG'
+        ],
+        'cflags_cc!': [
+          '-O3',
+          '-Os',
+          '-DNDEBUG'
+        ],
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS!': [
+            '-O3',
+            '-Os',
+            '-DDEBUG'
+          ],
+          'GCC_OPTIMIZATION_LEVEL': '0',
+          'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES'
+        }
+      },
+      'Release': {
+        'defines': [
+          'NDEBUG'
+        ],
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS!': [
+            '-Os',
+            '-O2'
+          ],
+          'GCC_OPTIMIZATION_LEVEL': '3',
+          'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
+          'DEAD_CODE_STRIPPING': 'YES',
+          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES'
+        }
+      }
+    }
+  }
+}

--- a/deps/utf8cpp/utf8/checked.h
+++ b/deps/utf8cpp/utf8/checked.h
@@ -134,7 +134,7 @@ namespace utf8
     }
 
     template <typename octet_iterator>
-    uint32_t next(octet_iterator& it, octet_iterator end)
+    FORCE_INLINE uint32_t next(octet_iterator& it, octet_iterator end)
     {
         uint32_t cp = 0;
         internal::utf_error err_code = utf8::internal::validate_next(it, end, cp);

--- a/deps/utf8cpp/utf8/core.h
+++ b/deps/utf8cpp/utf8/core.h
@@ -30,6 +30,12 @@ DEALINGS IN THE SOFTWARE.
 
 #include <iterator>
 
+# ifdef NDEBUG
+#  define FORCE_INLINE inline __attribute__((always_inline))
+# else
+#  define FORCE_INLINE
+# endif
+
 namespace utf8
 {
     // The typedefs for 8-bit, 16-bit and 32-bit unsigned integers
@@ -56,47 +62,47 @@ namespace internal
     const uint32_t CODE_POINT_MAX      = 0x0010ffffu;
 
     template<typename octet_type>
-    inline uint8_t mask8(octet_type oc)
+    FORCE_INLINE uint8_t mask8(octet_type oc)
     {
         return static_cast<uint8_t>(0xff & oc);
     }
     template<typename u16_type>
-    inline uint16_t mask16(u16_type oc)
+    FORCE_INLINE uint16_t mask16(u16_type oc)
     {
         return static_cast<uint16_t>(0xffff & oc);
     }
     template<typename octet_type>
-    inline bool is_trail(octet_type oc)
+    FORCE_INLINE bool is_trail(octet_type oc)
     {
         return ((utf8::internal::mask8(oc) >> 6) == 0x2);
     }
 
     template <typename u16>
-    inline bool is_lead_surrogate(u16 cp)
+    FORCE_INLINE bool is_lead_surrogate(u16 cp)
     {
         return (cp >= LEAD_SURROGATE_MIN && cp <= LEAD_SURROGATE_MAX);
     }
 
     template <typename u16>
-    inline bool is_trail_surrogate(u16 cp)
+    FORCE_INLINE bool is_trail_surrogate(u16 cp)
     {
         return (cp >= TRAIL_SURROGATE_MIN && cp <= TRAIL_SURROGATE_MAX);
     }
 
     template <typename u16>
-    inline bool is_surrogate(u16 cp)
+    FORCE_INLINE bool is_surrogate(u16 cp)
     {
         return (cp >= LEAD_SURROGATE_MIN && cp <= TRAIL_SURROGATE_MAX);
     }
 
     template <typename u32>
-    inline bool is_code_point_valid(u32 cp)
+    FORCE_INLINE bool is_code_point_valid(u32 cp)
     {
         return (cp <= CODE_POINT_MAX && !utf8::internal::is_surrogate(cp));
     }
 
     template <typename octet_iterator>
-    inline typename std::iterator_traits<octet_iterator>::difference_type
+    FORCE_INLINE typename std::iterator_traits<octet_iterator>::difference_type
     sequence_length(octet_iterator lead_it)
     {
         uint8_t lead = utf8::internal::mask8(*lead_it);
@@ -113,7 +119,7 @@ namespace internal
     }
 
     template <typename octet_difference_type>
-    inline bool is_overlong_sequence(uint32_t cp, octet_difference_type length)
+    FORCE_INLINE bool is_overlong_sequence(uint32_t cp, octet_difference_type length)
     {
         if (cp < 0x80) {
             if (length != 1) 
@@ -150,7 +156,7 @@ namespace internal
 
     /// get_sequence_x functions decode utf-8 sequences of the length x
     template <typename octet_iterator>
-    utf_error get_sequence_1(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    FORCE_INLINE utf_error get_sequence_1(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
         if (it == end)
             return NOT_ENOUGH_ROOM;
@@ -161,7 +167,7 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    utf_error get_sequence_2(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    FORCE_INLINE utf_error get_sequence_2(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
         if (it == end) 
             return NOT_ENOUGH_ROOM;
@@ -176,7 +182,7 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    utf_error get_sequence_3(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    FORCE_INLINE utf_error get_sequence_3(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
         if (it == end)
             return NOT_ENOUGH_ROOM;
@@ -195,7 +201,7 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    utf_error get_sequence_4(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    FORCE_INLINE utf_error get_sequence_4(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
         if (it == end)
            return NOT_ENOUGH_ROOM;
@@ -220,7 +226,7 @@ namespace internal
     #undef UTF8_CPP_INCREASE_AND_RETURN_ON_ERROR
 
     template <typename octet_iterator>
-    utf_error validate_next(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    FORCE_INLINE utf_error validate_next(octet_iterator& it, octet_iterator end, uint32_t& code_point)
     {
         // Save the original value of it so we can go back in case of failure
         // Of course, it does not make much sense with i.e. stream iterators
@@ -272,7 +278,7 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    inline utf_error validate_next(octet_iterator& it, octet_iterator end) {
+    FORCE_INLINE utf_error validate_next(octet_iterator& it, octet_iterator end) {
         uint32_t ignored;
         return utf8::internal::validate_next(it, end, ignored);
     }
@@ -297,13 +303,13 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    inline bool is_valid(octet_iterator start, octet_iterator end)
+    FORCE_INLINE bool is_valid(octet_iterator start, octet_iterator end)
     {
         return (utf8::find_invalid(start, end) == end);
     }
 
     template <typename octet_iterator>
-    inline bool starts_with_bom (octet_iterator it, octet_iterator end)
+    FORCE_INLINE bool starts_with_bom (octet_iterator it, octet_iterator end)
     {
         return (
             ((it != end) && (utf8::internal::mask8(*it++)) == bom[0]) &&
@@ -314,7 +320,7 @@ namespace internal
 	
     //Deprecated in release 2.3 
     template <typename octet_iterator>
-    inline bool is_bom (octet_iterator it)
+    FORCE_INLINE bool is_bom (octet_iterator it)
     {
         return (
             (utf8::internal::mask8(*it++)) == bom[0] &&

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "Andrew Pendleton <andrew@mapbox.com>",
   "license": "MIT",
   "dependencies": {
-    "nan": "2.0.9",
-    "node-pre-gyp": "0.5.x"
+    "nan": "2.4.0",
+    "node-pre-gyp": "0.6.x"
   },
   "bundledDependencies":["node-pre-gyp"],
   "devDependencies": {

--- a/src/addon.cxx
+++ b/src/addon.cxx
@@ -17,8 +17,7 @@
 
 NAN_METHOD(decode) {
   try {
-      v8::Local<v8::String> val = info[0].As<v8::String>();
-      v8::String::Utf8Value utf8_value(val);
+      Nan::Utf8String utf8_value(info[0]);
       int len = utf8_value.length();
       if (len <= 0) {
           // This is done to match behavior of JS module
@@ -37,8 +36,7 @@ NAN_METHOD(decode) {
 
 NAN_METHOD(decodable) {
   try {
-      v8::Local<v8::String> val = info[0].As<v8::String>();
-      v8::String::Utf8Value utf8_value(val);
+      Nan::Utf8String utf8_value(info[0]);
       int len = utf8_value.length();
       if (len <= 0) {
           // This is done to match behavior of JS module

--- a/src/addon.cxx
+++ b/src/addon.cxx
@@ -31,7 +31,6 @@ NAN_METHOD(decode) {
           info.GetReturnValue().Set(Nan::New(output.data(),output.size()).ToLocalChecked());
       }
   } catch (std::exception const& ex) {
-      //std::clog << ex.what() << "\n";
       return Nan::ThrowTypeError(ex.what());
   }
 }

--- a/src/addon.cxx
+++ b/src/addon.cxx
@@ -1,28 +1,64 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wconversion"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #include <nan.h>
+#pragma clang diagnostic pop
+
 #include <string>
 #include "unidecode.cxx"
 
-using v8::FunctionTemplate;
-using v8::Handle;
-using v8::Object;
-using v8::String;
-using Nan::GetFunction;
-using Nan::New;
-using Nan::Set;
-
-
 NAN_METHOD(decode) {
-  String::Utf8Value utf8_value(info[0].As<String>());
-  string input = string(*utf8_value, utf8_value.length());
-  string output;
-  unidecode(&input, &output);
-
-  info.GetReturnValue().Set(New(output).ToLocalChecked());
+  try {
+      v8::Local<v8::String> val = info[0].As<v8::String>();
+      v8::String::Utf8Value utf8_value(val);
+      int len = utf8_value.length();
+      if (len <= 0) {
+          // This is done to match behavior of JS module
+          info.GetReturnValue().Set(Nan::New("").ToLocalChecked());
+      } else {
+          std::string output;
+          std::size_t ulen = static_cast<std::size_t>(len);
+          output.reserve(ulen);
+          unidecode(*utf8_value, ulen, output);
+          info.GetReturnValue().Set(Nan::New(output.data(),output.size()).ToLocalChecked());
+      }
+  } catch (std::exception const& ex) {
+      //std::clog << ex.what() << "\n";
+      return Nan::ThrowTypeError(ex.what());
+  }
 }
 
+NAN_METHOD(decodable) {
+  try {
+      v8::Local<v8::String> val = info[0].As<v8::String>();
+      v8::String::Utf8Value utf8_value(val);
+      int len = utf8_value.length();
+      if (len <= 0) {
+          // This is done to match behavior of JS module
+          info.GetReturnValue().Set(Nan::New<v8::Boolean>(false));
+      } else {
+          std::size_t ulen = static_cast<std::size_t>(len);
+          info.GetReturnValue().Set(Nan::New<v8::Boolean>(can_decode(*utf8_value, ulen)));
+      }
+  } catch (std::exception const& ex) {
+      return Nan::ThrowTypeError(ex.what());
+  }
+}
+
+
 NAN_MODULE_INIT(InitAll) {
-  Set(target, New<String>("decode").ToLocalChecked(),
-    GetFunction(New<FunctionTemplate>(decode)).ToLocalChecked());
+  Nan::Set(target, Nan::New<v8::String>("decode").ToLocalChecked(),
+    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(decode)).ToLocalChecked());
+  Nan::Set(target, Nan::New<v8::String>("decodable").ToLocalChecked(),
+    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(decodable)).ToLocalChecked());
 }
 
 NODE_MODULE(unidecode, InitAll)

--- a/test/unidecode.mocha.js
+++ b/test/unidecode.mocha.js
@@ -24,7 +24,13 @@ describe('# Purity tests', function(){
 	tests.forEach(function(test) {
 		it(test.charCodeAt(0).toString(16) + ' ' + test, function(){
 			var exp = test;
-			var res = unidecode(exp);
+			var res = unidecode.decode(exp);
+			var decodable = unidecode.decodable(exp);
+			if (res.length > 0) {
+				assert.ok(decodable);
+			} else {
+				assert.ok(!decodable);
+			}
 			assert.equal(res, exp);
 		});
 	});
@@ -44,7 +50,7 @@ describe('# Basic string tests', function(){
 	tests.forEach(function(test) {
 		it(test, function(){
 			var exp = test;
-			var res = unidecode(test.toString());
+			var res = unidecode.decode(test.toString());
 			assert.equal(res, exp);
 		});
 	});
@@ -79,7 +85,7 @@ describe('# Complex tests', function(){
 	tests.forEach(function(test) {
 		it(test[0] + '-->' + test[1], function(){
 			var exp = test[1];
-			var res = unidecode(test[0]);
+			var res = unidecode.decode(test[0]);
 			assert.equal(res, exp);
 		});
 	});
@@ -92,7 +98,7 @@ describe("# Match upstream behavior", function() {
 		var error = false;
 		for (var j = 0; j < lines.length; j++) {
 			var upstream = unidecodeOrig(lines[j]);
-			var current = unidecode(lines[j]);
+			var current = unidecode.decode(lines[j]);
 
 			if (upstream != current) {
 				console.log("no match");

--- a/unidecode.js
+++ b/unidecode.js
@@ -3,4 +3,4 @@ var path = require('path');
 var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
 var binding = require(binding_path);
 
-module.exports = binding.decode;
+module.exports = binding;


### PR DESCRIPTION
This PR optimizes the `decode` function by reducing memory allocations of `std::string` (by calling `string.reserve` and avoiding the creation of an extra string and instead sending the utf8 bytes directly to the `decode` function.

It also adds a new `decodable` function which can be used to test if the string is decodable without incurring the overhead of any string allocation at all.

The `decodable` would speed up this check: https://github.com/mapbox/carmen/blob/4233aab6acde8d7217065ab1f077e07cb90cdadc/lib/util/termops.js#L135

Running `bench.js` before this PR:

```
unidecodeCxx: 688ms
```

And after:

```
cxx decodable: 162ms
cxx decode: 431ms
```

/cc @apendleton @yhahn 